### PR TITLE
Fix for 6-digit codes logging for Windows SDK

### DIFF
--- a/sdk-features/6-digit-codes.md
+++ b/sdk-features/6-digit-codes.md
@@ -230,7 +230,7 @@ public async Task StartCobrowse()
 private void OnSessionUpdated(Session session)
 {
   if (session.Code != null)
-    Debug.WriteLine("Created session code: {0}", session.Code);
+    Debug.WriteLine($"Created session code: {0}", session.Code);
 }
 ```
 


### PR DESCRIPTION
Fixed logging of 6-digit code as your customer says. They're absolutely right. A bug.