### PR TITLE
Redaction by default instructions for React Native

### DIFF
--- a/sdk-features/listening-for-events.md
+++ b/sdk-features/listening-for-events.md
@@ -201,3 +201,57 @@ CobrowseIO.instance().setDelegate(/* your delegate implementation */);
 ```
 {% endtab %}
 {% endtabs %}
+
+#### Using the delegates on React Native
+
+To use the Delegate objects within React Native you can follow the examples below.
+
+{% tabs %}
+{% tab title="iOS / MacOS" %}
+
+Ensure that your `AppDelegate` implements the `RCTCobrowseIODelegate` protocol.
+
+```objectivec
+// ios/Example/AppDelegate.h
+// ...
+#import <RCTCobrowseIO.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate, RCTCobrowseIODelegate>
+```
+
+You should then instanciate the delegate in the application function as such:
+
+```objectivec
+// ios/Example/AppDelegate.m
+    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+        // ...
+
+        RCTCobrowseIO.delegate = self;
+    }
+```
+
+Finally, you can define the methods as required. You can refer to [this commit](https://github.com/cobrowseio/cobrowse-sdk-react-native/commit/db4ed8a57da53c2acc0310975f5eeda914db05f7) on our SDK for an example.
+{% endtab %}
+
+**Note:** For newer versions of React Native you may need to to enable **C++ modules** to use the delegate. To do this, you can pass the `-fmodules` or `-fcxx-modules` flags to the "Other C++ Flags" under your project build settings. Remember to do this for any build configuration (ie: Debug, Release and so on).
+
+{% tab title="Android" %}
+
+Ensure that your `MainApplication` implements the desired delegate and assign the instance of your application to the `CobrowseIOModule.delegate`. For this example we'll use the `RedactionDelegate`:
+
+```java
+// android/app/src/main/java/com/example/MainApplication.java
+
+// ...
+import io.cobrowse.reactnative.CobrowseIO;
+import io.cobrowse.reactnative.CobrowseIOModule;
+
+public class MainApplication extends Application implements ReactApplication, CobrowseIO.RedactionDelegate {
+    // ... 
+
+    CobrowseIOModule.delegate = this;
+}
+```
+
+From this you can override the methods you need. You can refer to [this commit](https://github.com/cobrowseio/cobrowse-sdk-react-native/commit/00e3036c2247b8a20ed705543ca9df4aa54218f6) for a reference implementation within our React Native example app.
+{% endtab %}

--- a/sdk-features/redact-sensitive-data.md
+++ b/sdk-features/redact-sensitive-data.md
@@ -77,6 +77,34 @@ export default class MyComponent extends Component {
 
 // ... stylesheets etc...
 ```
+
+You can also enable redaction by default which will ensure that all the content inside the selected root view will be hidden to the agents. This is particularly useful on applications that require a higher privacy standard or where only specific sections of the App should be visible to the agent.
+
+To achieve this, you'll need to follow the [delegate implementation](listening-for-events.md#session-updated-events) and ensure you pass the root views to the Cobrowse `cobrowseRedactedViewsForViewController` and `redactedViews` methods for iOS and Android respectively. Once you've done this, your application Root Views will be redacted by default and you'll be able to un-redact child components to make them visible to the agents:
+
+```
+import React, { Component } from 'react';
+import { Text, View } from 'react-native';
+import { Unredacted } from 'cobrowse-sdk-react-native';
+
+export default class MyComponent extends Component {
+    render() {
+        return (
+            <View style={styles.container}>
+                <Text>This text should be secret due to the redaction by default implementation</Text>
+                <Unredacted>
+                    <Text>This text will be visible to the agents because it's wrapped with an Unredacted component</Text>
+                    <Redacted>
+                        <Text>You can also nest redacted elements inside unredacted ones. This text will be hidden to the agents.</Text>
+                    </Redacted>
+                </Unredacted>
+            </View>
+        );
+    }
+}
+```
+
+Finally, within React Native some packages will render in new Windows/Root Views. You can follow the same [delegate implementation](listening-for-events.md#session-updated-events) to identify this views and redact or unredact them by default as required. You can check the provided examples for [iOS](https://github.com/cobrowseio/cobrowse-sdk-react-native/blob/master/Example/ios/Example/AppDelegate.m) and [Android](https://github.com/cobrowseio/cobrowse-sdk-react-native/blob/master/Example/android/app/src/main/java/com/example/MainApplication.java) which redact by default the React Native Dev menu keeping one of the options unredacted to illustrate the technique.
 {% endtab %}
 
 {% tab title="Xamarin" %}
@@ -316,3 +344,5 @@ Enter your tag of the view class and/or the identifier name for the view, e.g. `
 `tag` is the [simple name](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getSimpleName--) of the view class, `#id` can usually be found in the XML layout like so `android:id="@+id/here_is_the_id`. The `#id` must be able to be used with system `android.view.View#findViewById()` and `android.app.Activity#findViewById()` methods.
 {% endtab %}
 {% endtabs %}
+
+### Redaction by default

--- a/sdk-installation/react-native.md
+++ b/sdk-installation/react-native.md
@@ -8,10 +8,10 @@ description: React Native SDK
 
 ```bash
 npm install --save cobrowse-sdk-react-native
-react-native link
+(cd ios && pod install)
 ```
 
-**Note:** For `react-native link` to work out of the box on iOS, you need to be using Pods to manage dependencies. Please also remember to run `pod install` after the link step. Depending on your project, you may also need `use_frameworks!` in your Podfile. If using Pods causes a problem for your project, you may use Carthage to manage your Cobrowse.io dependencies, or you may also add the frameworks to your project by hand. More info at [iOS SDK Installation](ios.md).&#x20;
+**Note:** For older versions of React Native, you may need to run `react-native link` before running `pod install`. Depending on your project, you may also need `use_frameworks!` in your Podfile. If using Pods causes a problem for your project, you may use Carthage to manage your Cobrowse.io dependencies, or you may also add the frameworks to your project by hand. More info at [iOS SDK Installation](ios.md).
 
 ### Add your License Key
 


### PR DESCRIPTION
This PR adds instructions on how to use redaction by default on React Native through the delegate objects exposed by the iOS and Android native SDKs