### PR TITLE
chore: recommend mongo 7.0 or 8.x

### DIFF
--- a/enterprise-self-hosting/self-hosting-overview.md
+++ b/enterprise-self-hosting/self-hosting-overview.md
@@ -38,7 +38,7 @@ Any questions or specific requirements to review? Please email us at [hello@cobr
 
 Depending on your choice, your deployment will already include specific versions of these components which you can adjust to your preference.
 
-MongoDB: We recommend 7.x or 8.x for new deployments. The absolute minimum supported version is 3.2, but using an end-of-life version this old is strongly discouraged.
+MongoDB: We recommend 7.0 or 8.x for new deployments.
 
 Redis: 6.x or 7.x but earlier versions are very likely supported. New deployments are recommended to use the latest available version.
 


### PR DESCRIPTION
- Removes the backward compatibility notices with 3.2. Although this is likely still supported by the app, indexes are now re-created through migration which are not backgrounded by default on versions prior to 4.2. On those older versions, index creation during our migrations will block. 3.2 was unsupported 7 years ago, we shouldn't bend over backwards for outdated versions.
- Mongo supports .0 releases long-term, whereas .x releases are only supported for a short period.


This came about due to the work in https://github.com/cobrowseio/cobrowse-api/pull/328/changes